### PR TITLE
Implemented support for automatically mocking secondary dependencies.

### DIFF
--- a/src/AutoMoq.Tests/AutoMoqerTests.cs
+++ b/src/AutoMoq.Tests/AutoMoqerTests.cs
@@ -27,6 +27,21 @@ namespace AutoMoq.Tests
             var concreteClass = mocker.Resolve<ClassWithDependencies>();
             concreteClass.ShouldNotBeNull();
         }
+
+        [Test]
+        public void Can_resolve_a_nested_dependency_without_injection()
+        {
+            var concreteClass = mocker.Resolve<ClassWithNestedDependencies>();
+            concreteClass.DependencyWithDependencies.Dependency.ShouldNotBeNull();
+        }
+
+        [Test]
+        public void Can_inject_a_nested_dependency()
+        {
+            var nestedDependency = mocker.GetMock<IDependency>();
+            var concreteClass = mocker.Resolve<ClassWithNestedDependencies>();
+            concreteClass.DependencyWithDependencies.Dependency.ShouldBeSameAs(nestedDependency.Object);
+        }
     }
 
     public class ConcreteClass
@@ -45,5 +60,20 @@ namespace AutoMoq.Tests
 
     public interface IDependency
     {
+    }
+
+    public class ClassWithNestedDependencies
+    {
+        public IDependencyWithDependencies DependencyWithDependencies { get; set; }
+
+        public ClassWithNestedDependencies(IDependencyWithDependencies dependencyWithDependencies)
+        {
+            DependencyWithDependencies = dependencyWithDependencies;
+        }
+    }
+
+    public interface IDependencyWithDependencies
+    {
+        IDependency Dependency { get; }
     }
 }


### PR DESCRIPTION
If my class Concrete class depends on interface IA, and IA exposes a property B which is an interface of type IB, then the instance of the class would see a null reference when inspecting property B on its IA reference.

I have added the functionality to automatically mock IB, so the concrete class will be able to call functions on this without getting a NullReferenceException. And also being able to control the behavior of this using GetMock<IB>

I know that this might not be desirable in all cases, and would be a breaking functionality for existing tests, so perhaps some kind of AutoMockBehavior could be introduced to allow the default behavior to remain unchanged. But IMHO this new behavior would be the most desirable.
