### PR TITLE
Added support for injecting non-mocked object into the container

### DIFF
--- a/src/AutoMoq.Tests/AutoMoq.Tests.csproj
+++ b/src/AutoMoq.Tests/AutoMoq.Tests.csproj
@@ -65,6 +65,7 @@
   <ItemGroup>
     <Compile Include="AutoMoqerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="EnsureMoqTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AutoMoq\AutoMoq.csproj">

--- a/src/AutoMoq.Tests/EnsureMoqTests.cs
+++ b/src/AutoMoq.Tests/EnsureMoqTests.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using Moq;
+using NUnit.Framework;
+
+namespace AutoMoq.Tests.PullRequest
+{
+    [TestFixture]
+    // ReSharper disable InconsistentNaming
+    public class EnsureMoqTests
+    {
+        [Test]
+        public void GetMock_on_interface_returns_mock()
+        {
+            //Arrange
+            var mocker = new AutoMoqer();
+
+            //Act
+            var mock = mocker.GetMock<IDependency>();
+
+            //Assert
+            Assert.IsNotNull(mock);
+        }
+
+        [Test]
+        public void GetMock_on_concrete_returns_mock()
+        {
+            //Arrange
+            var mocker = new AutoMoqer();
+
+            //Act
+            var mock = mocker.GetMock<ConcreteClass>();
+
+            //Assert
+            Assert.IsNotNull(mock);
+        }
+
+
+        [Test]
+        public void Resolve_doesnt_return_mock()
+        {
+            //Arrange
+            var mocker = new AutoMoqer();
+
+            //Act
+            var result = mocker.Resolve<ConcreteClass>().Do();
+
+            //Assert
+            Assert.AreEqual("hello", result);
+        }
+
+        [Test]
+        public void Resolve_with_dependency_doesnt_return_mock()
+        {
+            //Arrange
+            var mocker = new AutoMoqer();
+
+            //Act
+            var result = mocker.Resolve<VirtualDependency>().VirtualMethod();
+
+            //Assert
+            Assert.AreEqual("hello", result);
+        }
+
+        [Test]
+        public void Resolve_with_mocked_dependency_uses_mock()
+        {
+            //Arrange
+            var mocker = new AutoMoqer();
+
+            mocker.GetMock<VirtualDependency>()
+                .Setup(m => m.VirtualMethod())
+                .Returns("mocked");
+
+            //Act
+            var result = mocker.Resolve<ClassWithVirtualDependencies>().CallVirtualChild();
+
+            //Assert
+            Assert.AreEqual("mocked", result);
+        }
+
+
+        [Test]
+        public void Resolve_with_unbound_concerete_dependency_uses_mock()
+        {
+            //Arrange
+            var mocker = new AutoMoqer();
+
+            //Act
+            var result = mocker.Resolve<ClassWithVirtualDependencies>().CallVirtualChild();
+
+            var mockedResult = new Mock<VirtualDependency>().Object.VirtualMethod();
+
+            //Assert
+            Assert.AreEqual((object) mockedResult, result);
+        }
+
+
+        [Test]
+        public void Resolve_with_constant_concerete_dependency_uses_constant()
+        {
+            //Arrange
+            var mocker = new AutoMoqer();
+
+            var constant = new VirtualDependency() { PropValue = Guid.NewGuid().ToString() };
+
+            mocker.SetConstant(constant);
+
+            //Act
+            var result = mocker.Resolve<ClassWithVirtualDependencies>().GetVirtualProperty();
+
+            //Assert
+            Assert.AreEqual((object) constant.PropValue, result);
+        }
+
+    }
+
+    #region Test Types
+
+    public class ConcreteClass
+    {
+        public string Do()
+        {
+            return "hello";
+        }
+    }
+
+    public class Dependency : IDependency { }
+
+    public interface IDependency { }
+
+    public class ClassWithDependencies
+    {
+        public IDependency Dependency { get; set; }
+
+        public ClassWithDependencies(IDependency dependency)
+        {
+            Dependency = dependency;
+        }
+    }
+
+    public class ClassWithVirtualDependencies
+    {
+        private readonly VirtualDependency _virtualDependency;
+        public IDependency Dependency { get; set; }
+
+        public ClassWithVirtualDependencies(IDependency dependency, VirtualDependency virtualDependency)
+        {
+            _virtualDependency = virtualDependency;
+            Dependency = dependency;
+        }
+
+        public string CallVirtualChild()
+        {
+            return _virtualDependency.VirtualMethod();
+        }
+
+        public string GetVirtualProperty()
+        {
+            return _virtualDependency.PropValue;
+        }
+    }
+
+    public class VirtualDependency
+    {
+        private readonly IDependency _dependency;
+
+        public string PropValue { get; set; }
+
+        public VirtualDependency() { }
+
+        public VirtualDependency(IDependency dependency)
+        {
+            _dependency = dependency;
+        }
+
+        public virtual string VirtualMethod()
+        {
+            return "hello";
+        }
+    }
+    #endregion
+
+}

--- a/src/AutoMoq/Unity/AutoMockingBuilderStrategy.cs
+++ b/src/AutoMoq/Unity/AutoMockingBuilderStrategy.cs
@@ -38,12 +38,14 @@ namespace AutoMoq.Unity
 
         private bool AMockObjectShouldBeCreatedForThisType(Type type)
         {
-            return TypeIsNotRegistered(type) && type.IsInterface;
+            var mocker = container.Resolve<AutoMoqer>();
+            return TypeIsNotRegistered(type) && (mocker.ResolveType == null || mocker.ResolveType != type);
+            //return TypeIsNotRegistered(type) && type.IsInterface;
         }
 
         private static Type GetTheTypeFromTheBuilderContext(IBuilderContext context)
         {
-            return ((NamedTypeBuildKey) context.OriginalBuildKey).Type;
+            return ((NamedTypeBuildKey)context.OriginalBuildKey).Type;
         }
 
         private bool TypeIsNotRegistered(Type type)
@@ -60,19 +62,19 @@ namespace AutoMoq.Unity
 
         private Mock InvokeTheMockCreationMethod(MethodInfo createMethod)
         {
-            return (Mock) createMethod.Invoke(mockFactory, new object[] {new List<object>().ToArray()});
+            return (Mock)createMethod.Invoke(mockFactory, new object[] { new List<object>().ToArray() });
         }
 
         private MethodInfo GenerateAnInterfaceMockCreationMethod(Type type)
         {
             var createMethodWithNoParameters = mockFactory.GetType().GetMethod("Create", EmptyArgumentList());
 
-            return createMethodWithNoParameters.MakeGenericMethod(new[] {type});
+            return createMethodWithNoParameters.MakeGenericMethod(new[] { type });
         }
 
         private static Type[] EmptyArgumentList()
         {
-            return new[] {typeof (object[])};
+            return new[] { typeof(object[]) };
         }
 
         #endregion


### PR DESCRIPTION
I personally needed support for this since I needed to a an actual database provider into my class to test database interaction.

 current implementation is kind of sketchy since it adds the functional type into the repo but also adds a mocked version to the mock dictionary.
