### PR TITLE
Mock behavior changes

### DIFF
--- a/src/AutoMoq.Tests/AutoMoq.Tests.csproj
+++ b/src/AutoMoq.Tests/AutoMoq.Tests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="AutoMoqerTests.cs" />
     <Compile Include="AutoMoqTestFixtureTests.cs" />
     <Compile Include="ConfigTests.cs" />
+    <Compile Include="ConstructorTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="EnsureMoqTests.cs" />
     <Compile Include="QuestionsAboutMockerGettingCalledTwice.cs" />

--- a/src/AutoMoq.Tests/AutoMoq.Tests.csproj
+++ b/src/AutoMoq.Tests/AutoMoq.Tests.csproj
@@ -83,6 +83,7 @@
   <ItemGroup>
     <Compile Include="AutoMoqerTests.cs" />
     <Compile Include="AutoMoqTestFixtureTests.cs" />
+    <Compile Include="ConfigTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="EnsureMoqTests.cs" />
     <Compile Include="QuestionsAboutMockerGettingCalledTwice.cs" />

--- a/src/AutoMoq.Tests/AutoMoq.Tests.csproj
+++ b/src/AutoMoq.Tests/AutoMoq.Tests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="EnsureMoqTests.cs" />
     <Compile Include="QuestionsAboutMockerGettingCalledTwice.cs" />
     <Compile Include="Scenario\HttpContextBaseExample.cs" />
+    <Compile Include="MockingBehaviorTests.cs" />
     <Compile Include="with_automoqer_tests.cs" />
     <Compile Include="AutoMoqListTests.cs" />
   </ItemGroup>

--- a/src/AutoMoq.Tests/AutoMoqTestFixtureTests.cs
+++ b/src/AutoMoq.Tests/AutoMoqTestFixtureTests.cs
@@ -3,6 +3,7 @@ using AutoMoq.Helpers;
 using Microsoft.Practices.Unity;
 using Moq;
 using NUnit.Framework;
+using Should;
 
 namespace AutoMoq.Tests
 {
@@ -63,6 +64,31 @@ namespace AutoMoq.Tests
             Assert.AreNotSame(origDependency, fixture.Mocked<IDependency>());
 		}
 
+        [Test]
+        public void ResetSubject_should_allow_a_different_config_to_be_passed()
+        {
+            var fixture = new AutoMoqTestFixture<Apple>();
+
+            var looseConfig = new Config {MockBehavior = MockBehavior.Loose};
+            fixture.ResetSubject(looseConfig);
+
+            fixture.Subject.DoSomething(); // expecting no error
+
+            var strictConfig = new Config {MockBehavior = MockBehavior.Strict};
+            fixture.ResetSubject(strictConfig);
+
+            var errorHit = false;
+            try
+            {
+                fixture.Subject.DoSomething(); // expecting an error
+            }
+            catch
+            {
+                errorHit = true;
+            }
+            errorHit.ShouldBeTrue();
+        }
+
 		[Test]
 		public void Mocker_should_be_set()
 		{
@@ -70,5 +96,25 @@ namespace AutoMoq.Tests
 
 			Assert.IsNotNull(fixture.Mocker);
 		}
+
+        public class Apple
+        {
+            private readonly IOrange orange;
+
+            public Apple(IOrange orange)
+            {
+                this.orange = orange;
+            }
+
+            public void DoSomething()
+            {
+                orange.Something();
+            }
+        }
+
+        public interface IOrange
+        {
+            void Something();
+        }
     }
 }

--- a/src/AutoMoq.Tests/AutoMoqerTests.cs
+++ b/src/AutoMoq.Tests/AutoMoqerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.CodeDom;
+using System.Configuration;
 using Moq;
 using NUnit.Framework;
 using Should;
@@ -9,21 +10,36 @@ namespace AutoMoq.Tests
     [TestFixture]
     public class StrictMockTests
     {
-        private AutoMoqer mocker;
-
-        [SetUp]
-        public void Setup()
-        {
-            mocker = new AutoMoqer();
-        }
-
         [Test]
         public void It_should_support_loose_mocking()
         {
+            var mocker = new AutoMoqer();
             var bar = mocker.Create<Bar>();
             bar.Throw();
             // an error should not be thrown, as this
             // is a loose mock
+        }
+
+        [Test]
+        public void It_should_support_strict_mocking()
+        {
+
+            var config = new Config(){MockBehavior = MockBehavior.Strict};
+            var mocker = new AutoMoqer(config);
+
+            var bar = mocker.Create<Bar>();
+
+            var anErrorWasThrown = false;
+            try
+            {
+                bar.Throw();
+            }
+            catch
+            {
+                anErrorWasThrown = true;
+            }
+            anErrorWasThrown.ShouldBeTrue();
+
         }
 
         public class Bar

--- a/src/AutoMoq.Tests/AutoMoqerTests.cs
+++ b/src/AutoMoq.Tests/AutoMoqerTests.cs
@@ -1,10 +1,53 @@
 ﻿using System;
+using System.CodeDom;
 using Moq;
 using NUnit.Framework;
 using Should;
 
 namespace AutoMoq.Tests
 {
+    [TestFixture]
+    public class StrictMockTests
+    {
+        private AutoMoqer mocker;
+
+        [SetUp]
+        public void Setup()
+        {
+            mocker = new AutoMoqer();
+        }
+
+        [Test]
+        public void It_should_support_loose_mocking()
+        {
+            var bar = mocker.Create<Bar>();
+            bar.Throw();
+            // an error should not be thrown, as this
+            // is a loose mock
+        }
+
+        public class Bar
+        {
+            private readonly IFoo foo;
+
+            public Bar(IFoo foo)
+            {
+                this.foo = foo;
+            }
+
+            public void Throw()
+            {
+                foo.Catch();
+            }
+        }
+
+        public interface IFoo
+        {
+            void Catch();
+        }
+        
+    }
+
     [TestFixture]
     public class AutoMoqerTests
     {

--- a/src/AutoMoq.Tests/AutoMoqerTests.cs
+++ b/src/AutoMoq.Tests/AutoMoqerTests.cs
@@ -8,63 +8,6 @@ using Should;
 namespace AutoMoq.Tests
 {
     [TestFixture]
-    public class StrictMockTests
-    {
-        [Test]
-        public void It_should_support_loose_mocking()
-        {
-            var mocker = new AutoMoqer();
-            var bar = mocker.Create<Bar>();
-            bar.Throw();
-            // an error should not be thrown, as this
-            // is a loose mock
-        }
-
-        [Test]
-        public void It_should_support_strict_mocking()
-        {
-
-            var config = new Config(){MockBehavior = MockBehavior.Strict};
-            var mocker = new AutoMoqer(config);
-
-            var bar = mocker.Create<Bar>();
-
-            var anErrorWasThrown = false;
-            try
-            {
-                bar.Throw();
-            }
-            catch
-            {
-                anErrorWasThrown = true;
-            }
-            anErrorWasThrown.ShouldBeTrue();
-
-        }
-
-        public class Bar
-        {
-            private readonly IFoo foo;
-
-            public Bar(IFoo foo)
-            {
-                this.foo = foo;
-            }
-
-            public void Throw()
-            {
-                foo.Catch();
-            }
-        }
-
-        public interface IFoo
-        {
-            void Catch();
-        }
-        
-    }
-
-    [TestFixture]
     public class AutoMoqerTests
     {
         private AutoMoqer mocker;

--- a/src/AutoMoq.Tests/ConfigTests.cs
+++ b/src/AutoMoq.Tests/ConfigTests.cs
@@ -1,0 +1,20 @@
+using Moq;
+using NUnit.Framework;
+using Should;
+
+namespace AutoMoq.Tests
+{
+    public class ConfigTests
+    {
+        [TestFixture]
+        public class MockBehaviorTests
+        {
+            [Test]
+            public void It_should_default_to_loose()
+            {
+                var config = new Config();
+                config.MockBehavior.ShouldEqual(MockBehavior.Loose);
+            }
+        }
+    }
+}

--- a/src/AutoMoq.Tests/ConstructorTests.cs
+++ b/src/AutoMoq.Tests/ConstructorTests.cs
@@ -36,6 +36,21 @@ namespace AutoMoq.Tests
             bar.Foo.ShouldBeSameAs(foo);
         }
 
+        [Test]
+        public void I_can_replace_the_unity_container_with_my_own_through_config()
+        {
+            var container = new UnityContainer();
+            var config = new Config() {Container = container};
+
+            var foo = new Mock<IFoo>().Object;
+            container.RegisterInstance(foo);
+
+            var mocker = new AutoMoqer(config);
+
+            var bar = mocker.Create<Bar>();
+            bar.Foo.ShouldBeSameAs(foo);
+        }
+
         public interface IFoo
         {
         }

--- a/src/AutoMoq.Tests/ConstructorTests.cs
+++ b/src/AutoMoq.Tests/ConstructorTests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Practices.Unity;
+using Moq;
+using NUnit.Framework;
+using Should;
+
+namespace AutoMoq.Tests
+{
+    [TestFixture]
+    public class ConstructorTests
+    {
+        [Test]
+        public void I_can_instantiate_a_working_automoqer_with_no_dependencies()
+        {
+            var mocker = new AutoMoqer();
+
+            var bar = mocker.Create<Bar>();
+            bar.Foo.ShouldBeSameAs(mocker.GetMock<IFoo>().Object);
+        }
+
+        [Test]
+        public void I_can_replace_the_unity_container_with_my_own()
+        {
+            var container = new UnityContainer();
+
+            var foo = new Mock<IFoo>().Object;
+            container.RegisterInstance(foo);
+
+            var mocker = new AutoMoqer(container);
+
+            var bar = mocker.Create<Bar>();
+            bar.Foo.ShouldBeSameAs(foo);
+        }
+
+        public interface IFoo
+        {
+        }
+
+        public class Bar
+        {
+            public IFoo Foo { get; set; }
+
+            public Bar(IFoo foo)
+            {
+                Foo = foo;
+            }
+        }
+    }
+}

--- a/src/AutoMoq.Tests/MockingBehaviorTests.cs
+++ b/src/AutoMoq.Tests/MockingBehaviorTests.cs
@@ -1,0 +1,63 @@
+using Moq;
+using NUnit.Framework;
+using Should;
+
+namespace AutoMoq.Tests
+{
+    [TestFixture]
+    public class MockingBehaviorTests
+    {
+        [Test]
+        public void It_should_support_loose_mocking()
+        {
+            var mocker = new AutoMoqer();
+            var bar = mocker.Create<Bar>();
+            bar.Throw();
+            // an error should not be thrown, as this
+            // is a loose mock
+        }
+
+        [Test]
+        public void It_should_support_strict_mocking()
+        {
+
+            var config = new Config(){MockBehavior = MockBehavior.Strict};
+            var mocker = new AutoMoqer(config);
+
+            var bar = mocker.Create<Bar>();
+
+            var anErrorWasThrown = false;
+            try
+            {
+                bar.Throw();
+            }
+            catch
+            {
+                anErrorWasThrown = true;
+            }
+            anErrorWasThrown.ShouldBeTrue();
+
+        }
+
+        public class Bar
+        {
+            private readonly IFoo foo;
+
+            public Bar(IFoo foo)
+            {
+                this.foo = foo;
+            }
+
+            public void Throw()
+            {
+                foo.Catch();
+            }
+        }
+
+        public interface IFoo
+        {
+            void Catch();
+        }
+        
+    }
+}

--- a/src/AutoMoq.Tests/with_automoqer_tests.cs
+++ b/src/AutoMoq.Tests/with_automoqer_tests.cs
@@ -25,6 +25,27 @@ namespace AutoMoq.Tests
         }
 
         [Test]
+        public void A_config_option_can_be_provided_when_setting_up()
+        {
+            with_automoqer.mocker = null;
+            new with_automoqer(new Config {MockBehavior = MockBehavior.Loose});
+
+            with_automoqer.Create<Test>().DoSomething(); // should not fail
+
+            new with_automoqer(new Config {MockBehavior = MockBehavior.Strict});
+            var errorHit = false;
+            try
+            {
+                with_automoqer.Create<Test>().DoSomething(); // should fail
+            }
+            catch
+            {
+                errorHit = true;
+            }
+            errorHit.ShouldBeTrue();
+        }
+
+        [Test]
         public void GetMock_returns_the_mock()
         {
             var test = new with_automoqer();
@@ -56,6 +77,7 @@ namespace AutoMoq.Tests
 
         public interface IDependency
         {
+            void DoSomething();
         }
 
         public class Test
@@ -65,6 +87,11 @@ namespace AutoMoq.Tests
             public Test(IDependency Dependency)
             {
                 this.Dependency = Dependency;
+            }
+
+            public void DoSomething()
+            {
+                Dependency.DoSomething();
             }
         }
     }

--- a/src/AutoMoq/AutoMoq.csproj
+++ b/src/AutoMoq/AutoMoq.csproj
@@ -72,6 +72,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AutoMoqer.cs" />
+    <Compile Include="Config.cs" />
     <Compile Include="Helpers\AutoMoqTestFixture.cs" />
     <Compile Include="Helpers\with_automoqer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/AutoMoq/AutoMoqer.cs
+++ b/src/AutoMoq/AutoMoqer.cs
@@ -30,7 +30,7 @@ namespace AutoMoq
 
         public AutoMoqer(Config config)
         {
-            SetupAutoMoqer(new UnityContainer(), config);
+            SetupAutoMoqer(config.Container ?? new UnityContainer(), config);
         }
 
         /// <summary>

--- a/src/AutoMoq/AutoMoqer.cs
+++ b/src/AutoMoq/AutoMoqer.cs
@@ -20,12 +20,17 @@ namespace AutoMoq
 
         public AutoMoqer()
         {
-            SetupAutoMoqer(new UnityContainer());
+            SetupAutoMoqer(new UnityContainer(), new Config());
         }
 
         public AutoMoqer(IUnityContainer container)
         {
-            SetupAutoMoqer(container);
+            SetupAutoMoqer(container, new Config());
+        }
+
+        public AutoMoqer(Config config)
+        {
+            SetupAutoMoqer(new UnityContainer(), config);
         }
 
         /// <summary>
@@ -162,17 +167,18 @@ namespace AutoMoq
             GetMock<T>().Verify(expression, times, failMessage);
         }
 
-        private void SetupAutoMoqer(IUnityContainer container)
+        private void SetupAutoMoqer(IUnityContainer container, Config config)
         {
             this.container = container;
             registeredMocks = new Dictionary<Type, object>();
 
-            AddTheAutoMockingContainerExtensionToTheContainer(container);
+            AddTheAutoMockingContainerExtensionToTheContainer(container, config);
             container.RegisterInstance(this);
         }
 
-        private static void AddTheAutoMockingContainerExtensionToTheContainer(IUnityContainer container)
+        private static void AddTheAutoMockingContainerExtensionToTheContainer(IUnityContainer container, Config config)
         {
+            container.RegisterInstance(config);
             container.AddNewExtension<AutoMockingContainerExtension>();
         }
 

--- a/src/AutoMoq/AutoMoqer.cs
+++ b/src/AutoMoq/AutoMoqer.cs
@@ -20,17 +20,18 @@ namespace AutoMoq
 
         public AutoMoqer()
         {
-            SetupAutoMoqer(new UnityContainer(), new Config());
+            SetupAutoMoqer(new Config());
         }
 
         public AutoMoqer(IUnityContainer container)
         {
-            SetupAutoMoqer(container, new Config());
+            var config = new Config {Container = container};
+            SetupAutoMoqer(config);
         }
 
         public AutoMoqer(Config config)
         {
-            SetupAutoMoqer(config.Container ?? new UnityContainer(), config);
+            SetupAutoMoqer(config);
         }
 
         /// <summary>
@@ -167,9 +168,9 @@ namespace AutoMoq
             GetMock<T>().Verify(expression, times, failMessage);
         }
 
-        private void SetupAutoMoqer(IUnityContainer container, Config config)
+        private void SetupAutoMoqer(Config config)
         {
-            this.container = container;
+            this.container = config.Container;
             registeredMocks = new Dictionary<Type, object>();
 
             AddTheAutoMockingContainerExtensionToTheContainer(container, config);

--- a/src/AutoMoq/Config.cs
+++ b/src/AutoMoq/Config.cs
@@ -1,10 +1,12 @@
-﻿using Moq;
+﻿using Microsoft.Practices.Unity;
+using Moq;
 
 namespace AutoMoq
 {
     public class Config
     {
         public MockBehavior MockBehavior { get; set; }
+        public IUnityContainer Container { get; set; }
 
         public Config()
         {

--- a/src/AutoMoq/Config.cs
+++ b/src/AutoMoq/Config.cs
@@ -1,0 +1,14 @@
+﻿using Moq;
+
+namespace AutoMoq
+{
+    public class Config
+    {
+        public MockBehavior MockBehavior { get; set; }
+
+        public Config()
+        {
+            MockBehavior = MockBehavior.Loose;
+        }
+    }
+}

--- a/src/AutoMoq/Config.cs
+++ b/src/AutoMoq/Config.cs
@@ -5,13 +5,13 @@ namespace AutoMoq
 {
     public class Config
     {
-        public MockBehavior MockBehavior { get; set; }
-        public IUnityContainer Container { get; set; }
-
         public Config()
         {
             MockBehavior = MockBehavior.Loose;
             Container = new UnityContainer();
         }
+
+        public MockBehavior MockBehavior { get; set; }
+        public IUnityContainer Container { get; set; }
     }
 }

--- a/src/AutoMoq/Config.cs
+++ b/src/AutoMoq/Config.cs
@@ -11,6 +11,7 @@ namespace AutoMoq
         public Config()
         {
             MockBehavior = MockBehavior.Loose;
+            Container = new UnityContainer();
         }
     }
 }

--- a/src/AutoMoq/Helpers/AutoMoqTestFixture.cs
+++ b/src/AutoMoq/Helpers/AutoMoqTestFixture.cs
@@ -70,5 +70,15 @@ namespace AutoMoq.Helpers
             Mocker = new AutoMoqer();
             subject = null;
         }
+
+        /// <summary>
+        ///     Resets Subject instance.  A new instance will be created, with new depenencies auto-injected.
+        /// </summary>
+        /// <param name="config"></param>
+        public void ResetSubject(Config config)
+        {
+            Mocker = new AutoMoqer(config);
+            subject = null;
+        }
     }
 }

--- a/src/AutoMoq/Helpers/with_automoqer.cs
+++ b/src/AutoMoq/Helpers/with_automoqer.cs
@@ -11,6 +11,11 @@ namespace AutoMoq.Helpers
             mocker = new AutoMoqer();
         }
 
+        public with_automoqer(Config config)
+        {
+            mocker = new AutoMoqer(config);
+        }
+
         public static Mock<T> GetMock<T>() where T : class
         {
             return mocker.GetMock<T>();

--- a/src/AutoMoq/Properties/AssemblyInfo.cs
+++ b/src/AutoMoq/Properties/AssemblyInfo.cs
@@ -8,9 +8,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("AutoMoq")]
 [assembly: AssemblyDescription("Automocker for Moq.")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("DEG")]
+[assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("AutoMoq")]
-[assembly: AssemblyCopyright("Copyright © Darren Cauthon 2010")]
+[assembly: AssemblyCopyright("Copyright © Darren Cauthon 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -35,5 +35,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("1.6.2.0")]
-[assembly: AssemblyFileVersion("1.6.2.0")]
+[assembly: AssemblyVersion("1.7.0.0")]
+[assembly: AssemblyFileVersion("1.7.0.0")]

--- a/src/AutoMoq/Unity/AutoMockingContainerExtension.cs
+++ b/src/AutoMoq/Unity/AutoMockingContainerExtension.cs
@@ -7,7 +7,13 @@ namespace AutoMoq.Unity
 {
     internal class AutoMockingContainerExtension : UnityContainerExtension
     {
+        private readonly Config config;
         private readonly IList<Type> registeredTypes = new List<Type>();
+
+        public AutoMockingContainerExtension(Config config)
+        {
+            this.config = config;
+        }
 
         protected override void Initialize()
         {
@@ -30,7 +36,7 @@ namespace AutoMoq.Unity
 
         private void SetBuildingStrategyForBuildingUnregisteredTypes()
         {
-            var strategy = new MoqBuilderStrategy(registeredTypes, Container);
+            var strategy = new MoqBuilderStrategy(registeredTypes, Container, config);
             Context.Strategies.Add(strategy, UnityBuildStage.PreCreation);
         }
 

--- a/src/AutoMoq/Unity/MoqBuilderStrategy.cs
+++ b/src/AutoMoq/Unity/MoqBuilderStrategy.cs
@@ -10,10 +10,10 @@ namespace AutoMoq.Unity
     {
         private readonly MockRepository mockRepository;
 
-        public MoqBuilderStrategy(IEnumerable<Type> registeredTypes, IUnityContainer container)
+        public MoqBuilderStrategy(IEnumerable<Type> registeredTypes, IUnityContainer container, Config config)
             : base(registeredTypes, container)
         {
-            mockRepository = new MockRepository(MockBehavior.Loose);
+            mockRepository = new MockRepository(config.MockBehavior);
         }
 
         public override MockCreationResult CreateAMockObject(Type type)


### PR DESCRIPTION
Added the ability to support strict mocking. 

But the big change here is the idea of a "config" object, which will be used to pass along certain bits of behavior that need to be configured.  This config object will have anything relevant to the setup of the auto-mocking container.

But as for mocking behavior, here is how it could be changed now:

```c#
var config = new Config(){MockBehavior = MockBehavior.Strict};
var mocker = new AutoMoqer(config);
```