### PR TITLE
Mock behavior parameter

### DIFF
--- a/src/AutoMoq.Tests/MockingBehaviorTests.cs
+++ b/src/AutoMoq.Tests/MockingBehaviorTests.cs
@@ -64,6 +64,31 @@ namespace AutoMoq.Tests
 
         }
 
+        [Test]
+        public void It_should_allow_a_mock_to_be_changed_on_a_mock_by_mock_basis_case_2()
+        {
+            var mocker = new AutoMoqer();
+
+            mocker.GetMock<IFoo>(MockBehavior.Strict);
+            mocker.GetMock<IFooFoo>(MockBehavior.Loose);
+
+            var bar = mocker.Create<BarBar>();
+
+            bar.ThrowFooFoo(); // this one is loose, so it should not throw
+
+            var anErrorWasThrown = false;
+            try
+            {
+                bar.ThrowFoo(); // this one is strict, so it should throw
+
+            }
+            catch
+            {
+                anErrorWasThrown = true;
+            }
+            anErrorWasThrown.ShouldBeTrue();
+        }
+
         public class Bar
         {
             private readonly IFoo foo;

--- a/src/AutoMoq.Tests/MockingBehaviorTests.cs
+++ b/src/AutoMoq.Tests/MockingBehaviorTests.cs
@@ -39,6 +39,32 @@ namespace AutoMoq.Tests
 
         }
 
+        [Test]
+        public void It_should_allow_a_mock_to_be_changed_on_a_mock_by_mock_basis()
+        {
+
+            var mocker = new AutoMoqer();
+
+            mocker.GetMock<IFoo>(MockBehavior.Loose);
+            mocker.GetMock<IFooFoo>(MockBehavior.Strict);
+
+            var bar = mocker.Create<BarBar>();
+
+            bar.ThrowFoo(); // this one is loose, so it should not throw
+
+            var anErrorWasThrown = false;
+            try
+            {
+                bar.ThrowFooFoo(); // this one is strict, so it should throw
+            }
+            catch
+            {
+                anErrorWasThrown = true;
+            }
+            anErrorWasThrown.ShouldBeTrue();
+
+        }
+
         public class Bar
         {
             private readonly IFoo foo;
@@ -51,6 +77,33 @@ namespace AutoMoq.Tests
             public void Throw()
             {
                 foo.Catch();
+            }
+        }
+
+        public interface IFooFoo
+        {
+            void Catch();
+        }
+
+        public class BarBar
+        {
+            private readonly IFoo foo;
+            private readonly IFooFoo foofoo;
+
+            public BarBar(IFoo foo, IFooFoo foofoo)
+            {
+                this.foo = foo;
+                this.foofoo = foofoo;
+            }
+
+            public void ThrowFoo()
+            {
+                foo.Catch();
+            }
+
+            public void ThrowFooFoo()
+            {
+                foofoo.Catch();
             }
         }
 

--- a/src/AutoMoq.Tests/MockingBehaviorTests.cs
+++ b/src/AutoMoq.Tests/MockingBehaviorTests.cs
@@ -42,7 +42,6 @@ namespace AutoMoq.Tests
         [Test]
         public void It_should_allow_a_mock_to_be_changed_on_a_mock_by_mock_basis()
         {
-
             var mocker = new AutoMoqer();
 
             mocker.GetMock<IFoo>(MockBehavior.Loose);

--- a/src/AutoMoq/AutoMoq.nuspec
+++ b/src/AutoMoq/AutoMoq.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>AutoMoq</id>
-    <version>1.7.0.0</version>
+    <version>1.7.1.0</version>
     <title>AutoMoq</title>
     <authors>Darren Cauthon</authors>
     <owners>Darren Cauthon</owners>

--- a/src/AutoMoq/AutoMoqer.cs
+++ b/src/AutoMoq/AutoMoqer.cs
@@ -72,10 +72,10 @@ namespace AutoMoq
         /// </summary>
         /// <typeparam name="T">The type of mock to build.</typeparam>
         /// <returns>A mock object of type T.</returns>
-        public virtual Mock<T> GetMock<T>() where T : class
+        public virtual Mock<T> GetMock<T>(MockBehavior mockBehavior = MockBehavior.Default) where T : class
         {
             ResolveType = null;
-            return mocking.GetMockByCreatingAMockIfOneHasNotAlreadyBeenCreated<T>();
+            return mocking.GetMockByCreatingAMockIfOneHasNotAlreadyBeenCreated<T>(mockBehavior);
         }
 
         /// <summary>

--- a/src/AutoMoq/Mocking.cs
+++ b/src/AutoMoq/Mocking.cs
@@ -62,7 +62,10 @@ namespace AutoMoq
             var createMethodWithNoParameters = mockRepository.GetType().GetMethod("Create", types);
             var createMethod = createMethodWithNoParameters.MakeGenericMethod(type);
 
-            var objects = new List<object>().ToArray();
+            var list = new List<object>();
+            if (mockBehavior != MockBehavior.Default)
+                list.Add(mockBehavior);
+            var objects = list.ToArray();
             var mock = (Mock) createMethod.Invoke(mockRepository, new object[] {objects});
 
             return new MockCreationResult
@@ -88,7 +91,7 @@ namespace AutoMoq
 
         public MockCreationResult CreateANewMockObjectAndRegisterIt<T>(MockBehavior mockBehavior = MockBehavior.Default) where T : class
         {
-            var result = CreateAMockObjectFor(typeof (T));
+            var result = CreateAMockObjectFor(typeof (T), mockBehavior);
             var mock = (Mock<T>) result.MockObject;
             ioc.RegisterInstance(mock.Object);
             ioc.Resolve<AutoMoqer>().SetMock(typeof (T), mock);

--- a/src/AutoMoq/Mocking.cs
+++ b/src/AutoMoq/Mocking.cs
@@ -15,7 +15,6 @@ namespace AutoMoq
         MockCreationResult CreateAMockObjectFor(Type type);
         MockCreationResult CreateAMockObjectFor(Type type, MockBehavior mockBehavior);
         MockCreationResult CreateANewMockObjectAndRegisterIt(Type type);
-        MockCreationResult CreateANewMockObjectAndRegisterIt<T>() where T : class;
         void SetMock(Type type, object mock);
         void SetInstance<T>(T instance) where T : class;
         Mock<T> GetMockByCreatingAMockIfOneHasNotAlreadyBeenCreated<T>() where T : class;
@@ -82,11 +81,6 @@ namespace AutoMoq
             ioc.RegisterInstance(mock.Object);
             ioc.Resolve<AutoMoqer>().SetMock(type, mock);
             return result;
-        }
-
-        public MockCreationResult CreateANewMockObjectAndRegisterIt<T>() where T : class
-        {
-            throw new NotImplementedException();
         }
 
         public MockCreationResult CreateANewMockObjectAndRegisterIt<T>(MockBehavior mockBehavior = MockBehavior.Default) where T : class

--- a/src/AutoMoq/Mocking.cs
+++ b/src/AutoMoq/Mocking.cs
@@ -118,11 +118,6 @@ namespace AutoMoq
             return TheRegisteredMockForThisType<T>(type);
         }
 
-        private static Type[] EmptyArgumentList()
-        {
-            return new[] {typeof (object[])};
-        }
-
         private Mock<T> TheRegisteredMockForThisType<T>(Type type) where T : class
         {
             return (Mock<T>) GetTheRegisteredMockFor(type);

--- a/src/AutoMoq/Mocking.cs
+++ b/src/AutoMoq/Mocking.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using AutoMoq.Unity;
 using Moq;
 
@@ -51,15 +52,12 @@ namespace AutoMoq
 
         public MockCreationResult CreateAMockObjectFor(Type type, MockBehavior mockBehavior = MockBehavior.Default)
         {
-            var types = new[] {typeof (object[])};
-            var createMethodWithNoParameters = mockRepository.GetType().GetMethod("Create", types);
-            var createMethod = createMethodWithNoParameters.MakeGenericMethod(type);
+            var createMethod = mockRepository.GetType()
+                .GetMethod("Create", new[] {typeof (object[])}).MakeGenericMethod(type);
 
-            var list = new List<object>();
-            if (mockBehavior != MockBehavior.Default)
-                list.Add(mockBehavior);
-            var objects = list.ToArray();
-            var mock = (Mock) createMethod.Invoke(mockRepository, new object[] {objects});
+            var parameters = new List<object>();
+            if (mockBehavior != MockBehavior.Default) parameters.Add(mockBehavior);
+            var mock = (Mock) createMethod.Invoke(mockRepository, new object[] {parameters.ToArray()});
 
             return new MockCreationResult
             {

--- a/src/AutoMoq/Mocking.cs
+++ b/src/AutoMoq/Mocking.cs
@@ -12,7 +12,6 @@ namespace AutoMoq
         bool AMockHasNotBeenRegisteredFor(Type type);
         void RegisterThisMock(object mock, Type type);
         object GetTheRegisteredMockFor(Type type);
-        MockCreationResult CreateAMockObjectFor(Type type);
         MockCreationResult CreateAMockObjectFor(Type type, MockBehavior mockBehavior);
         MockCreationResult CreateANewMockObjectAndRegisterIt(Type type);
         void SetMock(Type type, object mock);
@@ -48,11 +47,6 @@ namespace AutoMoq
         public object GetTheRegisteredMockFor(Type type)
         {
             return RegisteredMocks.First(x => x.Key == type).Value;
-        }
-
-        public MockCreationResult CreateAMockObjectFor(Type type)
-        {
-            return CreateAMockObjectFor(type, MockBehavior.Default);
         }
 
         public MockCreationResult CreateAMockObjectFor(Type type, MockBehavior mockBehavior = MockBehavior.Default)


### PR DESCRIPTION
This is related to the request on #25 , https://github.com/darrencauthon/AutoMoq/pull/25#issuecomment-210711290 via @jpeckham

This will allow the mock behavior to be changed on a mock-by-mock basis, like this:

```c#
var mocker = new AutoMoqer();

mocker.GetMock<IFoo>(MockBehavior.Strict);
mocker.GetMock<IFooFoo>(MockBehavior.Loose);
```